### PR TITLE
chore: Revert BASE_URL constant to original value

### DIFF
--- a/src/renderer/src/config/constant.js
+++ b/src/renderer/src/config/constant.js
@@ -1,3 +1,3 @@
-// export const BASE_URL='http://192.168.1.215:8000/'
-export const BASE_URL='http://192.168.1.49:8000/'
+export const BASE_URL='http://192.168.1.215:8000/'
+// export const BASE_URL='http://192.168.1.49:8000/'
 // export const BASE_URL='https://projhub1.onrender.com/'


### PR DESCRIPTION
Revert the change made to the BASE_URL constant in the config file. The previous value was 'http://192.168.1.215:8000/' and it has been restored. This reverts the commit that updated the BASE_URL to 'http://192.168.1.49:8000/'.