### PR TITLE
chore: Remove resizable property from createWindow function

### DIFF
--- a/src/main/index.js
+++ b/src/main/index.js
@@ -10,7 +10,6 @@ function createWindow() {
     height: 980,
     show: false,
     autoHideMenuBar: true,
-    resizable: false,
     ...(process.platform === 'linux' ? { icon } : {}),
     webPreferences: {
       preload: join(__dirname, '../preload/index.js'),


### PR DESCRIPTION
This commit removes the `resizable` property from the `createWindow` function in `index.js`. The property was set to `false` but is no longer needed. This change improves the code by removing unnecessary configuration and simplifying the logic.