### PR TITLE
```text

### DIFF
--- a/src/renderer/src/components/dashboard/Sidebar.jsx
+++ b/src/renderer/src/components/dashboard/Sidebar.jsx
@@ -529,7 +529,7 @@ const Sidebar = ({ isSubMenuOpen, setIsSubMenuOpen }) => {
                         to="/dashboard/approve-assignee"
                         onClick={() => handleSubMenuClick('approve-assignee')}
                         className={`block py-2 ${
-                          activeSubMenu === 'approve-task'
+                          activeSubMenu === 'approve-assignee'
                             ? 'bg-white text-gray-900 pl-5 font-bold'
                             : ''
                         }`}


### PR DESCRIPTION
chore: Fix activeSubMenu value in Sidebar component

Update the activeSubMenu value in the Sidebar component to 'approve-assignee' instead of 'approve-task'. This change ensures that the correct menu item is highlighted when the user navigates to the 'approve-assignee' page.