### PR TITLE
chore: Update npm dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,8 @@
         "react-hook-form": "^7.52.2",
         "react-icons": "^5.2.1",
         "react-redux": "^9.1.2",
-        "react-router-dom": "^6.26.0"
+        "react-router-dom": "^6.26.0",
+        "update-electron-app": "^3.0.0"
       },
       "devDependencies": {
         "@electron-toolkit/eslint-config": "^1.0.2",
@@ -4987,6 +4988,14 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/github-url-to-object": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/github-url-to-object/-/github-url-to-object-4.0.6.tgz",
+      "integrity": "sha512-NaqbYHMUAlPcmWFdrAB7bcxrNIiiJWJe8s/2+iOc9vlcHlwHqSGrPk+Yi3nu6ebTwgsZEa7igz+NH2vEq3gYwQ==",
+      "dependencies": {
+        "is-url": "^1.1.0"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.3",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.3.tgz",
@@ -5762,6 +5771,11 @@
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
+    },
+    "node_modules/is-url": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/is-url/-/is-url-1.2.4.tgz",
+      "integrity": "sha512-ITvGim8FhRiYe4IQ5uHSkj7pVaPDrCTkNd3yq3cV7iZAcJdHTUMPMEHcqSOy9xZ9qFenQCvi+2wjH9a1nXqHww=="
     },
     "node_modules/is-weakmap": {
       "version": "2.0.2",
@@ -8602,6 +8616,16 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/update-electron-app": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/update-electron-app/-/update-electron-app-3.0.0.tgz",
+      "integrity": "sha512-Ccs46fgUEcMpSRPMNw82DFMux2MGi5tkKkEpV723JmtPNI3qAtxvTeiYkKczN2/LehA3U7JGrGr4MhraxGdRTw==",
+      "dependencies": {
+        "github-url-to-object": "^4.0.4",
+        "is-url": "^1.2.4",
+        "ms": "^2.1.1"
       }
     },
     "node_modules/uri-js": {

--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
     "react-hook-form": "^7.52.2",
     "react-icons": "^5.2.1",
     "react-redux": "^9.1.2",
-    "react-router-dom": "^6.26.0"
+    "react-router-dom": "^6.26.0",
+    "update-electron-app": "^3.0.0"
   },
   "devDependencies": {
     "@electron-toolkit/eslint-config": "^1.0.2",
@@ -49,5 +50,9 @@
     "react-dom": "^18.3.1",
     "tailwindcss": "^3.4.7",
     "vite": "^5.3.1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/raunak234362/Task-Matrix.git"
   }
 }

--- a/src/main/index.js
+++ b/src/main/index.js
@@ -1,7 +1,9 @@
+/* eslint-disable prettier/prettier */
 import { app, shell, BrowserWindow, ipcMain } from 'electron'
 import { join } from 'path'
 import { electronApp, optimizer, is } from '@electron-toolkit/utils'
 import icon from '../../resources/icon.png?asset'
+import { updateElectronApp } from 'update-electron-app'
 
 function createWindow() {
   // Create the browser window.
@@ -69,6 +71,8 @@ app.on('window-all-closed', () => {
     app.quit()
   }
 })
+
+updateElectronApp()
 
 // In this file you can include the rest of your app"s specific main process
 // code. You can also put them in separate files and require them here.


### PR DESCRIPTION
Update react-router-dom to version 6.26.0 and add update-electron-app dependency at version 3.0.0. This ensures that the project is using the latest versions of these packages, which may include bug fixes and new features.