### PR TITLE
chore: Update tag_name and release_name in build-and-upload.yml

### DIFF
--- a/.github/workflows/build-and-upload.yml
+++ b/.github/workflows/build-and-upload.yml
@@ -32,8 +32,8 @@ jobs:
       env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
-        tag_name: v1.0.0
-        release_name: Release v1.0.0
+        tag_name: v1.0.2
+        release_name: Release v1.0.2
         draft: false
         prerelease: false
     


### PR DESCRIPTION
Update the tag_name and release_name in the build-and-upload.yml file to v1.0.2 and Release v1.0.2 respectively. This change ensures that the correct version information is used for the release, aligning with the recent user commits and maintaining consistency with the repository's commit conventions.